### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ If you find any issues, please report them to us as there are very helpful!
 __API Key__
 
 As each of our Hypixel API keys must be kept private, none of the code will have any of our API keys within them or visible to you. If you dont already have an API key please log onto Hypixel and run the command `/api` and if there is already a key, `/apinew`
+
+[![Run on Repl.it](https://repl.it/badge/github/KarnaughMap/HypixelAPInfo)](https://repl.it/github/KarnaughMap/HypixelAPInfo)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).